### PR TITLE
Suppress `unused-but-set-variable` Warning

### DIFF
--- a/barretenberg/src/aztec/CMakeLists.txt
+++ b/barretenberg/src/aztec/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
-add_compile_options(-Werror -Wall -Wextra -Wconversion -Wsign-conversion -Wno-deprecated -Wno-tautological-compare -Wfatal-errors)
+add_compile_options(-Werror -Wall -Wextra -Wconversion -Wsign-conversion -Wno-deprecated -Wno-tautological-compare -Wfatal-errors -Wno-unused-but-set-variable)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     add_compile_options(-Wno-unguarded-availability-new -Wno-c99-extensions -fconstexpr-steps=100000000)


### PR DESCRIPTION
_Environment: M2 macOS_

Add the compilation flag `-Wno-unused-but-set-variable` to suppresses the potential `unused-but-set-variable` warning as it would be treated as a fatal error here.

One way to reproduce the warning would be to compile Noir Nargo, which gives:
```
/Users/…/noir/target/release/build/barretenberg_wrapper-4a960280e5361b48/out/build/_deps/leveldb-src/util/cache.cc:129:14: fatal error: variable 'count' set but not used [-Wunused-but-set-variable]
      uint32_t count = 0;
               ^
```

The warning should be a false positive in this case, as the var `count` is used a few lines down in the `cache.cc` file.

The warning does not seem to be reproducible when running `bootstrap.sh`.

Previous discussions / attempts on solving assumingly the same problem:
- Remove the `-Wfatal-errors` & `-Werror` flags ([PR](https://github.com/noir-lang/noir/pull/242), [`-Wfatal-errors` Removal Commit](https://github.com/AztecProtocol/barretenberg/commit/7db3a6ee34e58b9fe4fe52f45db7c567ffcfa556), [`-Werror` Removal Commit](https://github.com/AztecProtocol/barretenberg/commit/2e16d04ae2ca5a3d2c07f74df98b14a1b9dc917e))