### PR TITLE
Rename `c_bind.hpp` → `c_bind.h`

### DIFF
--- a/barretenberg/src/aztec/bb/bb.hpp
+++ b/barretenberg/src/aztec/bb/bb.hpp
@@ -5,4 +5,4 @@
 #include <ecc/curves/grumpkin/c_bind.hpp>
 #include <ecc/curves/bn254/scalar_multiplication/c_bind.hpp>
 #include <crypto/schnorr/c_bind.hpp>
-#include <dsl/standard_format/c_bind.hpp>
+#include <dsl/standard_format/c_bind.h>


### PR DESCRIPTION
Follow-up patch to changes in commit [d92b0453](https://github.com/noir-lang/aztec-connect/commit/d92b04535d3e4af5ad5a622d5483266844c17e08).