### PR TITLE
Fixed bindings to point to the standard_example

### DIFF
--- a/barretenberg/src/aztec/CMakeLists.txt
+++ b/barretenberg/src/aztec/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
-add_compile_options(-Werror -Wall -Wextra -Wconversion -Wsign-conversion -Wno-deprecated -Wno-tautological-compare -Wfatal-errors -Wno-unused-but-set-variable)
+add_compile_options(-Werror -Wall -Wextra -Wconversion -Wsign-conversion -Wno-deprecated -Wno-tautological-compare -Wfatal-errors)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     add_compile_options(-Wno-unguarded-availability-new -Wno-c99-extensions -fconstexpr-steps=100000000)

--- a/barretenberg/src/aztec/bb/bb.cpp
+++ b/barretenberg/src/aztec/bb/bb.cpp
@@ -3,4 +3,4 @@
 #include <ecc/curves/grumpkin/c_bind.cpp>
 #include <ecc/curves/bn254/scalar_multiplication/c_bind.cpp>
 #include <crypto/schnorr/c_bind.cpp>
-#include <dsl/standard_format/c_bind.cpp>
+#include <rollup/proofs/standard_example/c_bind.h>

--- a/barretenberg/src/aztec/bb/bb.hpp
+++ b/barretenberg/src/aztec/bb/bb.hpp
@@ -5,4 +5,4 @@
 #include <ecc/curves/grumpkin/c_bind.hpp>
 #include <ecc/curves/bn254/scalar_multiplication/c_bind.hpp>
 #include <crypto/schnorr/c_bind.hpp>
-#include <dsl/standard_format/c_bind.h>
+#include <rollup/proofs/standard_example/c_bind.h>

--- a/barretenberg/src/aztec/rollup/proofs/standard_example/c_bind.cpp
+++ b/barretenberg/src/aztec/rollup/proofs/standard_example/c_bind.cpp
@@ -22,6 +22,12 @@ WASM_EXPORT uint32_t standard_example__get_circuit_size(uint8_t const* constrain
     return rollup::proofs::standard_example::c_get_circuit_size(constraint_system_buf);
 }
 
+// Get the exact circuit size for the constraint system.
+WASM_EXPORT uint32_t standard_example__get_exact_circuit_size(uint8_t const* constraint_system_buf)
+{
+    return rollup::proofs::standard_example::c_get_exact_circuit_size(constraint_system_buf);
+}
+
 WASM_EXPORT void standard_example__init_proving_key()
 {
     auto crs_factory = std::make_unique<waffle::ReferenceStringFactory>();

--- a/barretenberg/src/aztec/rollup/proofs/standard_example/c_bind.h
+++ b/barretenberg/src/aztec/rollup/proofs/standard_example/c_bind.h
@@ -18,6 +18,8 @@ WASM_EXPORT void standard_example__delete_prover(void* prover);
 
 WASM_EXPORT bool standard_example__verify_proof(uint8_t* proof, uint32_t length);
 
+WASM_EXPORT uint32_t standard_example__get_exact_circuit_size(uint8_t const* constraint_system_buf);
+
 // Backwards compatibility
 WASM_EXPORT uint32_t composer__get_circuit_size(uint8_t const* constraint_system_buf);
 WASM_EXPORT uint32_t composer__smart_contract(void* pippenger,

--- a/barretenberg/src/aztec/rollup/proofs/standard_example/standard_example.cpp
+++ b/barretenberg/src/aztec/rollup/proofs/standard_example/standard_example.cpp
@@ -42,6 +42,16 @@ uint32_t c_get_circuit_size(uint8_t const* constraint_system_buf)
     return static_cast<uint32_t>(circuit_size);
 }
 
+uint32_t c_get_exact_circuit_size(uint8_t const* constraint_system_buf)
+{
+    auto constraint_system = from_buffer<waffle::standard_format>(constraint_system_buf);
+    auto crs_factory = std::make_unique<waffle::ReferenceStringFactory>();
+    auto composer = create_circuit(constraint_system, std::move(crs_factory));
+
+    auto num_gates = composer.get_num_gates();
+    return static_cast<uint32_t>(num_gates);
+}
+
 void init_proving_key(std::unique_ptr<waffle::ReferenceStringFactory>&& crs_factory)
 {
     auto composer = create_circuit(*constraint_system, std::move(crs_factory));

--- a/barretenberg/src/aztec/rollup/proofs/standard_example/standard_example.hpp
+++ b/barretenberg/src/aztec/rollup/proofs/standard_example/standard_example.hpp
@@ -32,6 +32,7 @@ bool verify_proof(waffle::plonk_proof const& proof);
 // and define the C++ method, we want to call in the standard_example.cpp file
 void c_init_circuit_def(uint8_t const* constraint_system_buf);
 uint32_t c_get_circuit_size(uint8_t const* constraint_system_buf);
+uint32_t c_get_exact_circuit_size(uint8_t const* constraint_system_buf);
 size_t c_composer__new_proof(void* pippenger,
                              uint8_t const* g2x,
                              uint8_t const* constraint_system_buf,

--- a/barretenberg_wrapper/build.rs
+++ b/barretenberg_wrapper/build.rs
@@ -197,6 +197,13 @@ fn main() {
     println!("cargo:rustc-link-lib=static=stdlib_schnorr");
     println!("cargo:rustc-link-lib=static=stdlib_pedersen");
 
+    println!(
+        "cargo:rustc-link-search={}/build/src/aztec/rollup/proofs/standard_example",
+        dst.display()
+    );
+    println!("cargo:rustc-link-lib=static=rollup_proofs_standard_example");
+
+
     // Generate bindings from a header file and place them in a bindings.rs file
     let bindings = bindgen::Builder::default()
         // Clang args so that we can use relative include paths

--- a/barretenberg_wrapper/build.rs
+++ b/barretenberg_wrapper/build.rs
@@ -203,7 +203,6 @@ fn main() {
     );
     println!("cargo:rustc-link-lib=static=rollup_proofs_standard_example");
 
-
     // Generate bindings from a header file and place them in a bindings.rs file
     let bindings = bindgen::Builder::default()
         // Clang args so that we can use relative include paths

--- a/barretenberg_wrapper/src/composer.rs
+++ b/barretenberg_wrapper/src/composer.rs
@@ -23,6 +23,10 @@ pub unsafe fn get_circuit_size(cs_prt: *const u8) -> u32 {
     // TODO test with a circuit of size 2^19 cf: https://github.com/noir-lang/noir/issues/12
 }
 
+pub unsafe fn get_exact_circuit_size(cs_prt: *const u8) -> u32 {
+    standard_example__get_exact_circuit_size(cs_prt)
+}
+
 /// # Safety
 /// pippenger must point to a valid Pippenger object
 pub unsafe fn create_proof(
@@ -47,30 +51,17 @@ pub unsafe fn verify(
     // This is not the case, if you take the proof directly from Barretenberg
     pippenger: *mut ::std::os::raw::c_void,
     proof: &[u8],
-    public_inputs: &[u8],
+    _public_inputs: &[u8], // TODO: remove this and update aztec_backend packages
     cs_ptr: &[u8],
     g2_ptr: &[u8],
 ) -> bool {
     let proof_ptr = proof.as_ptr() as *const u8;
-    let verified;
-    if !public_inputs.is_empty() {
-        verified = composer__verify_proof_with_public_inputs(
-            pippenger,
-            g2_ptr.as_ptr() as *const u8,
-            cs_ptr.as_ptr() as *const u8,
-            public_inputs.as_ptr() as *const u8,
-            proof_ptr as *mut u8,
-            proof.len() as u32,
-        );
-    } else {
-        verified = composer__verify_proof(
-            pippenger,
-            g2_ptr.as_ptr() as *const u8,
-            cs_ptr.as_ptr() as *const u8,
-            proof_ptr as *mut u8,
-            proof.len() as u32,
-        );
-    }
-
-    verified
+    
+    composer__verify_proof(
+        pippenger,
+        g2_ptr.as_ptr() as *const u8,
+        cs_ptr.as_ptr() as *const u8,
+        proof_ptr as *mut u8,
+        proof.len() as u32,
+    )
 }

--- a/barretenberg_wrapper/src/composer.rs
+++ b/barretenberg_wrapper/src/composer.rs
@@ -51,7 +51,6 @@ pub unsafe fn verify(
     // This is not the case, if you take the proof directly from Barretenberg
     pippenger: *mut ::std::os::raw::c_void,
     proof: &[u8],
-    _public_inputs: &[u8], // TODO: remove this and update aztec_backend packages
     cs_ptr: &[u8],
     g2_ptr: &[u8],
 ) -> bool {


### PR DESCRIPTION
The bindings were pointing to DSL rather than the standard example so C functions were missing

We also added an exact circuit size method so that we can benchmark circuits with their exact constraint size without the size being rounded to the power of 2.