### PR TITLE
change lib omp link lib name + fixes to stdlib

### DIFF
--- a/barretenberg/src/aztec/dsl/standard_format/merkle_membership_constraint.hpp
+++ b/barretenberg/src/aztec/dsl/standard_format/merkle_membership_constraint.hpp
@@ -42,6 +42,9 @@ void create_merkle_check_membership_constraint(waffle::TurboComposer& composer, 
     /// struct which requires the method create_witness_hashpath
     hash_path<waffle::TurboComposer> hash_path;
 
+    // In Noir we accept a hash path that only contains one hash per tree level
+    // It is ok to reuse the leaf as it will be overridden in check_subtree_membership when computing the current root
+    // at each tree level
     for (size_t i = 0; i < input.hash_path.size(); i++) {
         if (index_bits[i].get_value() == false) {
             field_t left = leaf;

--- a/barretenberg/src/aztec/dsl/standard_format/merkle_membership_constraint.hpp
+++ b/barretenberg/src/aztec/dsl/standard_format/merkle_membership_constraint.hpp
@@ -42,10 +42,16 @@ void create_merkle_check_membership_constraint(waffle::TurboComposer& composer, 
     /// struct which requires the method create_witness_hashpath
     hash_path<waffle::TurboComposer> hash_path;
 
-    for (size_t i = 0; i < input.hash_path.size(); i = i + 2) {
-        field_t left = field_t::from_witness_index(&composer, input.hash_path[i]);
-        field_t right = field_t::from_witness_index(&composer, input.hash_path[i + 1]);
-        hash_path.push_back(std::make_pair(left, right));
+    for (size_t i = 0; i < input.hash_path.size(); i++) {
+        if (index_bits[i].get_value() == false) {
+            field_t left = leaf;
+            field_t right = field_t::from_witness_index(&composer, input.hash_path[i]);
+            hash_path.push_back(std::make_pair(left, right));
+        } else {
+            field_t left = field_t::from_witness_index(&composer, input.hash_path[i]);
+            field_t right = leaf;
+            hash_path.push_back(std::make_pair(left, right));
+        }
     }
 
     auto exists = check_subtree_membership(root, hash_path, leaf, index_bits, 0);

--- a/barretenberg/src/aztec/rollup/proofs/standard_example/standard_example.cpp
+++ b/barretenberg/src/aztec/rollup/proofs/standard_example/standard_example.cpp
@@ -109,9 +109,6 @@ size_t c_composer__new_proof(void* pippenger,
     auto witness = from_buffer<std::vector<fr>>(witness_buf);
     auto composer = create_circuit_with_witness(constraint_system, witness, std::move(crs_factory));
 
-    bool checked_circuit_res = composer.check_circuit();
-    printf("check_circuit result: %d\n", checked_circuit_res);
-
     // aligned_free((void*)witness_buf);
     // aligned_free((void*)g2x);
     // aligned_free((void*)constraint_system_buf);

--- a/barretenberg/src/aztec/rollup/proofs/standard_example/standard_example.cpp
+++ b/barretenberg/src/aztec/rollup/proofs/standard_example/standard_example.cpp
@@ -48,6 +48,9 @@ uint32_t c_get_exact_circuit_size(uint8_t const* constraint_system_buf)
     auto crs_factory = std::make_unique<waffle::ReferenceStringFactory>();
     auto composer = create_circuit(constraint_system, std::move(crs_factory));
 
+    bool checked_circuit_res = composer.check_circuit();
+    printf("check_circuit result: %d\n", checked_circuit_res);
+
     auto num_gates = composer.get_num_gates();
     return static_cast<uint32_t>(num_gates);
 }
@@ -105,6 +108,9 @@ size_t c_composer__new_proof(void* pippenger,
 
     auto witness = from_buffer<std::vector<fr>>(witness_buf);
     auto composer = create_circuit_with_witness(constraint_system, witness, std::move(crs_factory));
+
+    bool checked_circuit_res = composer.check_circuit();
+    printf("check_circuit result: %d\n", checked_circuit_res);
 
     // aligned_free((void*)witness_buf);
     // aligned_free((void*)g2x);

--- a/barretenberg_wrapper/build.rs
+++ b/barretenberg_wrapper/build.rs
@@ -227,11 +227,15 @@ fn link_lib_omp(toolchain: &'static str) {
         ARM_APPLE => println!("cargo:rustc-link-search=/opt/homebrew/lib"),
         &_ => unimplemented!("lomp linking of {} is not supported", toolchain),
     }
-    if toolchain == ARM_LINUX {
-        // only arm linux uses gcc
-        println!("cargo:rustc-link-lib=gomp")
-    } else {
-        println!("cargo:rustc-link-lib=omp")
+    match toolchain {
+        ARM_LINUX => {
+            // only arm linux uses gcc
+            println!("cargo:rustc-link-lib=gomp")   
+        }
+        INTEL_APPLE | ARM_APPLE => {
+            println!("cargo:rustc-link-lib=omp")
+        }
+        &_ => println!("cargo:rustc-link-lib=omp5")
     }
 }
 

--- a/barretenberg_wrapper/build.rs
+++ b/barretenberg_wrapper/build.rs
@@ -231,7 +231,7 @@ fn link_lib_omp(toolchain: &'static str) {
         // only arm linux uses gcc
         println!("cargo:rustc-link-lib=gomp")
     } else {
-        println!("cargo:rustc-link-lib=omp")
+        println!("cargo:rustc-link-lib=omp5")
     }
 }
 

--- a/barretenberg_wrapper/build.rs
+++ b/barretenberg_wrapper/build.rs
@@ -231,7 +231,7 @@ fn link_lib_omp(toolchain: &'static str) {
         // only arm linux uses gcc
         println!("cargo:rustc-link-lib=gomp")
     } else {
-        println!("cargo:rustc-link-lib=omp5")
+        println!("cargo:rustc-link-lib=omp")
     }
 }
 


### PR DESCRIPTION
Previously `nargo` would not even build in the CI. I changed the link for non ARM based linux to use `omp5` rather than `omp`. I held off on changing the linker for `ARM_LINUX` but we should probably test this and change for ARM_LINUX build as well before merging. It looks that reason nargo was failing in the CI is that ubuntu-latest requires the `omp5` flag rather than `omp`. In order to build on my local machine I needed the `omp` flag. We have changed the CI build to use ubuntu-20.04 as in this PR (https://github.com/noir-lang/noir/pull/565), so I switched the libomp link to use `omp`. We can make the change to discern between ubuntu versions once we plan to upgrade the CI to use ubuntu-latest. For now, I think keeping the link name as `omp` is safest.

This PR also makes a couple fixes to std_lib funcs and DSL glue that was causing issues with Noir. 
1. How we constructing the merkle_membership constraints was incorrect as we were treating the hash path as a flattened list of pairs, however, we switched this in Noir to have a singular hash path as the merkle inclusion proof. I made a change in the C++ to reflect this.
2. schnorr had an unnecessary assert to check whether the points provided are on the grumpkin curve. This assert was causing failures when trying to fetch the circuit size without witness data. I replaced this assert with constraints to check whether a point is on the curve.