### PR TITLE
Set TESTING cmake option to OFF

### DIFF
--- a/barretenberg_wrapper/build.rs
+++ b/barretenberg_wrapper/build.rs
@@ -93,6 +93,7 @@ fn main() {
         .cxxflag("-fPIE")
         .env("NUM_JOBS", num_cpus::get().to_string())
         .define("TOOLCHAIN", toolchain)
+        .define("TESTING", "OFF")
         .always_configure(false)
         .build();
 


### PR DESCRIPTION
I noticed that the barretenberg cmake file contains an option called `TESTING`, but sets the option `ON` if unspecified. This updates the `build.rs` file to set `-DTESTING=OFF` when building barretenberg for noir.