### PR TITLE
Disable unused-but-set-variable error inside leveldb

### DIFF
--- a/barretenberg/src/aztec/stdlib/merkle_tree/CMakeLists.txt
+++ b/barretenberg/src/aztec/stdlib/merkle_tree/CMakeLists.txt
@@ -16,6 +16,7 @@ if(NOT WASM)
     target_compile_options(
         leveldb
         PRIVATE
+        -Wno-unused-but-set-variable
         -Wno-sign-conversion
         -Wno-unused-parameter
         -Wno-shorten-64-to-32


### PR DESCRIPTION
It seems that building leveldb 1.22 fails due to one variable that is set but unused. This disables that error when building leveldb.