### PR TITLE
Homebrew pathing for Intel Macs

### DIFF
--- a/barretenberg_wrapper/build.rs
+++ b/barretenberg_wrapper/build.rs
@@ -217,7 +217,7 @@ fn link_lib_omp(toolchain: &'static str) {
         }
         INTEL_APPLE => {
             let brew_prefix = find_brew_prefix();
-            println!("cargo:rustc-link-search={}/lib", brew_prefix)
+            println!("cargo:rustc-link-search={}/opt/libomp/lib", brew_prefix)
         },
         ARM_APPLE => {
             let brew_prefix = find_brew_prefix();

--- a/barretenberg_wrapper/build.rs
+++ b/barretenberg_wrapper/build.rs
@@ -215,7 +215,10 @@ fn link_lib_omp(toolchain: &'static str) {
             let llvm_dir = find_llvm_linux_path();
             println!("cargo:rustc-link-search={}/lib", llvm_dir)
         }
-        INTEL_APPLE => println!("cargo:rustc-link-search=/usr/local/lib"),
+        INTEL_APPLE => {
+            let brew_prefix = find_brew_prefix();
+            println!("cargo:rustc-link-search={}/lib", brew_prefix)
+        },
         ARM_APPLE => {
             let brew_prefix = find_brew_prefix();
             println!("cargo:rustc-link-search={}/opt/libomp/lib", brew_prefix)


### PR DESCRIPTION
Use `brew --prefix` to link libomp instead of hardcoding the path. `brew --prefix` returns `/usr/local` which is what is currently hardcoded. But this should prevent any errors in case that prefix ever changes.

More details about this change can be found in PR #9 