### PR TITLE
Add `#include <algorithm>` statements where necessary

### DIFF
--- a/barretenberg/src/aztec/crypto/pedersen/sidon_set/sidon_set.hpp
+++ b/barretenberg/src/aztec/crypto/pedersen/sidon_set/sidon_set.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <array>
 #include <vector>
 

--- a/barretenberg/src/aztec/crypto/schnorr/multisig.hpp
+++ b/barretenberg/src/aztec/crypto/schnorr/multisig.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <utility>
 
 #include "./schnorr.hpp"


### PR DESCRIPTION
I've been having troubles compiling Barretenberg recently and one of the types of errors I've been getting is:

```
In file included from /home/tom/Programming/aztec-connect/barretenberg/src/aztec/crypto/pedersen/sidon_pedersen.cpp:3:
/home/tom/Programming/aztec-connect/barretenberg/src/aztec/crypto/pedersen/./sidon_set/sidon_set.hpp:57:10: fatal error: no member named 'sort' in namespace 'std'
    std::sort(factors.begin(), factors.end());
    ~~~~~^
[ 35%] Built target crypto_blake2s
1 error generated.
```

Adding these include statements fixes all the instances of these errors (which are then replaced by a new unrelated error :disappointed:)