### PR TITLE
Add some Rust smoketesting CI for barretenberg_wrapper

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,93 @@
+name: Rust
+
+on: [push, pull_request]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check_n_test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+        toolchain:
+          - stable
+          - nightly
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.toolchain }}
+          override: true
+
+      - name: Install dependencies
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: sudo apt update && sudo apt install libomp-dev
+
+      - name: Install dependencies
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: brew install llvm libomp cmake
+
+      - name: Run cargo check
+        working-directory: "./barretenberg_wrapper"
+        run: |
+          cargo +${{ matrix.toolchain }} check --all-targets --verbose
+
+      - name: Run cargo test
+        working-directory: "./barretenberg_wrapper"
+        run: |
+          cargo +${{ matrix.toolchain }} test
+
+  clippy:
+    name: cargo clippy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - name: Install dependencies
+        run: sudo apt update && sudo apt install libomp-dev
+
+      - name: Run cargo clippy
+        working-directory: "./barretenberg_wrapper"
+        run: |
+          cargo clippy -- -D warnings
+
+  format:
+    name: cargo fmt
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - name: Install dependencies
+        run: sudo apt update && sudo apt install libomp-dev
+
+      - name: Run cargo fmt
+        working-directory: "./barretenberg_wrapper"
+        run: |
+          cargo fmt --all -- --check

--- a/barretenberg_wrapper/.cargo/config.toml
+++ b/barretenberg_wrapper/.cargo/config.toml
@@ -1,0 +1,6 @@
+# This ensures Clang (instead of GCC) is used as a linker on Linux.
+# See https://github.com/rust-lang/rust/issues/71515#issuecomment-935020057
+# These should apply when used as a library, as per
+# https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "linker=clang", "-C", "link-arg=-fuse-ld=lld"]

--- a/barretenberg_wrapper/build.rs
+++ b/barretenberg_wrapper/build.rs
@@ -219,7 +219,7 @@ fn link_lib_omp(toolchain: &'static str) {
         INTEL_APPLE => {
             let brew_prefix = find_brew_prefix();
             println!("cargo:rustc-link-search={}/opt/libomp/lib", brew_prefix)
-        },
+        }
         ARM_APPLE => {
             let brew_prefix = find_brew_prefix();
             println!("cargo:rustc-link-search={}/opt/libomp/lib", brew_prefix)
@@ -229,12 +229,12 @@ fn link_lib_omp(toolchain: &'static str) {
     match toolchain {
         ARM_LINUX => {
             // only arm linux uses gcc
-            println!("cargo:rustc-link-lib=gomp")   
+            println!("cargo:rustc-link-lib=gomp")
         }
         INTEL_APPLE | ARM_APPLE => {
             println!("cargo:rustc-link-lib=omp")
         }
-        &_ => println!("cargo:rustc-link-lib=omp5")
+        &_ => println!("cargo:rustc-link-lib=omp5"),
     }
 }
 

--- a/barretenberg_wrapper/src/composer.rs
+++ b/barretenberg_wrapper/src/composer.rs
@@ -55,7 +55,7 @@ pub unsafe fn verify(
     g2_ptr: &[u8],
 ) -> bool {
     let proof_ptr = proof.as_ptr() as *const u8;
-    
+
     composer__verify_proof(
         pippenger,
         g2_ptr.as_ptr() as *const u8,

--- a/barretenberg_wrapper/src/composer.rs
+++ b/barretenberg_wrapper/src/composer.rs
@@ -23,6 +23,8 @@ pub unsafe fn get_circuit_size(cs_prt: *const u8) -> u32 {
     // TODO test with a circuit of size 2^19 cf: https://github.com/noir-lang/noir/issues/12
 }
 
+/// # Safety
+/// cs_prt must point to a valid constraints system structure of type standard_format
 pub unsafe fn get_exact_circuit_size(cs_prt: *const u8) -> u32 {
     standard_example__get_exact_circuit_size(cs_prt)
 }

--- a/barretenberg_wrapper/src/pedersen.rs
+++ b/barretenberg_wrapper/src/pedersen.rs
@@ -72,17 +72,17 @@ mod tests {
             Test {
                 input_left: f_zero,
                 input_right: f_one,
-                expected_hex: "108800e84e0f1dafb9fdf2e4b5b311fd59b8b08eaf899634c59cc985b490234b",
+                expected_hex: "229fb88be21cec523e9223a21324f2e305aea8bff9cdbcb3d0c6bba384666ea1",
             },
             Test {
                 input_left: f_one,
                 input_right: f_one,
-                expected_hex: "00f1c7ea35a4cf7ea5e678fcc2a5fac5351a563a3ff021f0c4a4126462aa081f",
+                expected_hex: "26425ddf29b4af6ee91008e8dbcbee975653170eee849efd75abf8301dee114e",
             },
             Test {
                 input_left: f_one,
                 input_right: f_zero,
-                expected_hex: "2619a3512420b4d3c72e43fdadff5f5a3ec1b0e7d75cd1482159a7e21f6c6d6a",
+                expected_hex: "08f3cb4f0fdd7a9ef130c6d4590af6750b1475161020a198a56eced45078ccf2",
             },
         ];
 
@@ -107,8 +107,8 @@ mod tests {
         inputs.push(f_one);
 
         let (x, y) = encrypt(&inputs);
-        let expected_x = "108800e84e0f1dafb9fdf2e4b5b311fd59b8b08eaf899634c59cc985b490234b";
-        let expected_y = "2d43ef68df82e0adf74fed92b1bc950670b9806afcfbcda08bb5baa6497bdf14";
+        let expected_x = "229fb88be21cec523e9223a21324f2e305aea8bff9cdbcb3d0c6bba384666ea1";
+        let expected_y = "296b4b4605e586a91caa3202baad557628a8c56d0a1d6dff1a7ca35aed3029d5";
         assert_eq!(expected_x, hex::encode(x));
         assert_eq!(expected_y, hex::encode(y));
     }

--- a/barretenberg_wrapper/src/pedersen.rs
+++ b/barretenberg_wrapper/src/pedersen.rs
@@ -24,7 +24,7 @@ pub fn compress_many(inputs: &[[u8; 32]]) -> [u8; 32] {
     let mut buffer = Vec::new();
     let witness_len = inputs.len() as u32;
     buffer.extend_from_slice(&witness_len.to_be_bytes());
-    for assignment in &*inputs {
+    for assignment in inputs {
         buffer.extend_from_slice(assignment);
     }
 
@@ -40,7 +40,7 @@ pub fn encrypt(inputs_buffer: &[[u8; 32]]) -> ([u8; 32], [u8; 32]) {
     let buffer_len = inputs_buffer.len() as u32;
     let mut result = [0_u8; 64];
     buffer.extend_from_slice(&buffer_len.to_be_bytes());
-    for e in &*inputs_buffer {
+    for e in inputs_buffer {
         buffer.extend_from_slice(e);
     }
 


### PR DESCRIPTION
This adds some CI for the `barretenberg_wrapper` crate. I wanted to get this added so we are more comfortable with changes such as my #9 PR and #8 (which we'll want to rebase on this). I believe ARM support is on the GitHub Action roadmap, so we'll be able to expand this matrix in the future.

I also needed to fix some rust formatting and clippy stuff in separate commits. 

I'll also have some comments inline.

Depends upon #13 