### PR TITLE
Disable TESTING option inside barretenberg bootstrap

### DIFF
--- a/barretenberg/bootstrap.sh
+++ b/barretenberg/bootstrap.sh
@@ -44,7 +44,7 @@ fi
 
 # Build native.
 mkdir -p build && cd build
-cmake -DCMAKE_BUILD_TYPE=RelWithAssert -DTOOLCHAIN=$TOOLCHAIN ..
+cmake -DCMAKE_BUILD_TYPE=RelWithAssert -DTOOLCHAIN=$TOOLCHAIN -DTESTING=OFF ..
 cmake --build . --parallel
 cd ..
 
@@ -56,6 +56,6 @@ cd ..
 
 # Build WASM.
 mkdir -p build-wasm && cd build-wasm
-cmake -DTOOLCHAIN=wasm-linux-clang ..
+cmake -DTOOLCHAIN=wasm-linux-clang -DTESTING=OFF ..
 cmake --build . --parallel --target barretenberg.wasm
 cd ..


### PR DESCRIPTION
As per @TomAFrench in #14, some people might try to build barretenberg with the `bootstrap.sh` file inside its directory. Ideally, users would just allow the `build.rs` file do the building, but we can just set `-DTESTING=OFF` in case they don't.