### PR TITLE
Migrate CI to use reusable workflows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,16 +4,9 @@ on: [push, pull_request]
 
 jobs:
   check_n_test:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-        toolchain: [stable, nightly]
     name: cargo check & test
     uses: noir-lang/.github/.github/workflows/rust-test.yml@main
     with:
-      os: ${{ matrix.os }}
-      toolchain: ${{ matrix.toolchain }}
       working-directory: "./barretenberg_wrapper"
 
   clippy:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,92 +2,28 @@ name: Rust
 
 on: [push, pull_request]
 
-env:
-  CARGO_TERM_COLOR: always
-
 jobs:
   check_n_test:
-    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-        toolchain:
-          - stable
-          - nightly
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v3
-
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.toolchain }}
-          override: true
-
-      - name: Install dependencies
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: sudo apt update && sudo apt install libomp-dev
-
-      - name: Install dependencies
-        if: ${{ matrix.os == 'macos-latest' }}
-        run: brew install llvm libomp cmake
-
-      - name: Run cargo check
-        working-directory: "./barretenberg_wrapper"
-        run: |
-          cargo +${{ matrix.toolchain }} check --all-targets --verbose
-
-      - name: Run cargo test
-        working-directory: "./barretenberg_wrapper"
-        run: |
-          cargo +${{ matrix.toolchain }} test
+        os: [ubuntu-latest, macos-latest]
+        toolchain: [stable, nightly]
+    name: cargo check & test
+    uses: noir-lang/.github/.github/workflows/rust-test.yml@main
+    with:
+      os: ${{ matrix.os }}
+      toolchain: ${{ matrix.toolchain }}
+      working-directory: "./barretenberg_wrapper"
 
   clippy:
     name: cargo clippy
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v3
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: rustfmt, clippy
-
-      - name: Install dependencies
-        run: sudo apt update && sudo apt install libomp-dev
-
-      - name: Run cargo clippy
-        working-directory: "./barretenberg_wrapper"
-        run: |
-          cargo clippy -- -D warnings
+    uses: noir-lang/.github/.github/workflows/rust-clippy.yml@main
+    with:
+      working-directory: "./barretenberg_wrapper"
 
   format:
     name: cargo fmt
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v3
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: rustfmt, clippy
-
-      - name: Install dependencies
-        run: sudo apt update && sudo apt install libomp-dev
-
-      - name: Run cargo fmt
-        working-directory: "./barretenberg_wrapper"
-        run: |
-          cargo fmt --all -- --check
+    uses: noir-lang/.github/.github/workflows/rust-format.yml@main
+    with:
+      working-directory: "./barretenberg_wrapper"


### PR DESCRIPTION
This migrates our GitHub Actions to use reusable actions (available at https://github.com/noir-lang/.github/tree/main/.github/workflows).

I also took the opportunity to replace the `actions-rs/toolchain` action with https://github.com/dtolnay/rust-toolchain which seems to be an up-to-date action with similar behavior (and [David Tolnay](https://github.com/dtolnay) is a highly respected Rust dev). This means that we no longer have deprecation warnings in every run.