### PR TITLE
Fix compile failure when clang is missing a flag for leveldb

### DIFF
--- a/barretenberg/src/aztec/stdlib/merkle_tree/CMakeLists.txt
+++ b/barretenberg/src/aztec/stdlib/merkle_tree/CMakeLists.txt
@@ -16,6 +16,7 @@ if(NOT WASM)
     target_compile_options(
         leveldb
         PRIVATE
+        -Wno-unknown-warning-option
         -Wno-unused-but-set-variable
         -Wno-sign-conversion
         -Wno-unused-parameter


### PR DESCRIPTION
This fixes a build error the @guipublic was seeing by ensuring that leveldb is built even if the clang being used doesn't have the `-Wno-unused-but-set-variable` (the warning and flag came after llvm 11 but I'm not sure which one).

I tested this on an ubuntu VM on my laptop but I want to add a step to CI that tests the oldest version of clang we support (v10) 