### PR TITLE
fix(bb_wrapper): Disable assembly code in all cases

### DIFF
--- a/barretenberg_wrapper/build.rs
+++ b/barretenberg_wrapper/build.rs
@@ -216,17 +216,17 @@ fn link_lib_omp(toolchain: &'static str) {
     match toolchain {
         INTEL_LINUX | ARM_LINUX => {
             let llvm_dir = find_llvm_linux_path();
-            println!("cargo:rustc-link-search={}/lib", llvm_dir)
+            println!("cargo:rustc-link-search={llvm_dir}/lib")
         }
         INTEL_APPLE => {
             let brew_prefix = find_brew_prefix();
-            println!("cargo:rustc-link-search={}/opt/libomp/lib", brew_prefix)
+            println!("cargo:rustc-link-search={brew_prefix}/opt/libomp/lib")
         }
         ARM_APPLE => {
             let brew_prefix = find_brew_prefix();
-            println!("cargo:rustc-link-search={}/opt/libomp/lib", brew_prefix)
+            println!("cargo:rustc-link-search={brew_prefix}/opt/libomp/lib")
         }
-        &_ => unimplemented!("lomp linking of {} is not supported", toolchain),
+        &_ => unimplemented!("lomp linking of {toolchain} is not supported"),
     }
     match toolchain {
         ARM_LINUX | INTEL_APPLE | ARM_APPLE => {

--- a/barretenberg_wrapper/build.rs
+++ b/barretenberg_wrapper/build.rs
@@ -86,6 +86,8 @@ fn main() {
         .env("NUM_JOBS", num_cpus::get().to_string())
         .define("TOOLCHAIN", toolchain)
         .define("TESTING", "OFF")
+        .define("DISABLE_ASM", "ON")
+        .define("DISABLE_ADX", "ON")
         .always_configure(false)
         .build();
 


### PR DESCRIPTION
This change makes it so we never use assembly code in the underlying barretenberg. This is a temporary workaround to see if we can avoid `illegal instruction` errors in noir CI.