### PR TITLE
Disable AVX-512 optimisation

### DIFF
--- a/barretenberg/cmake/arch.cmake
+++ b/barretenberg/cmake/arch.cmake
@@ -6,6 +6,5 @@ if(WASM)
 endif()
 
 if(NOT WASM AND NOT APPLE AND NOT ARM) 
-#    add_compile_options(-march=skylake-avx512) # Required for AVX-512 extensions
     add_compile_options(-march=skylake)
 endif()

--- a/barretenberg/cmake/arch.cmake
+++ b/barretenberg/cmake/arch.cmake
@@ -7,5 +7,5 @@ endif()
 
 if(NOT WASM AND NOT APPLE AND NOT ARM) 
 #    add_compile_options(-march=skylake-avx512) # Required for AVX-512 extensions
-    add_compile_options(-march=haswell)
+    add_compile_options(-march=skylake)
 endif()

--- a/barretenberg/cmake/arch.cmake
+++ b/barretenberg/cmake/arch.cmake
@@ -5,6 +5,7 @@ if(WASM)
     add_compile_options(-fno-exceptions -fno-slp-vectorize)
 endif()
 
-if(NOT WASM AND NOT APPLE AND NOT ARM)
-    add_compile_options(-march=skylake-avx512)
+if(NOT WASM AND NOT APPLE AND NOT ARM) 
+#    add_compile_options(-march=skylake-avx512) # Required for AVX-512 extensions
+    add_compile_options(-march=haswell)
 endif()


### PR DESCRIPTION
This PR disables Barretenberg's AVX-512 optimisation for wider compatibility with legacy Intel CPUs, i.e. to eliminate the dreaded `illegal instruction` error. Tested on an Intel i7-7500U running Arch Linux. Ideally there would be a flag for this optimisation, so this should be treated as a temporary workaround. Note that this works independently of commit f95b4d3.