### PR TITLE
remove print check_circuit

### DIFF
--- a/barretenberg/src/aztec/rollup/proofs/standard_example/standard_example.cpp
+++ b/barretenberg/src/aztec/rollup/proofs/standard_example/standard_example.cpp
@@ -50,9 +50,6 @@ uint32_t c_get_exact_circuit_size(uint8_t const* constraint_system_buf)
     auto crs_factory = std::make_unique<waffle::ReferenceStringFactory>();
     auto composer = create_circuit(constraint_system, std::move(crs_factory));
 
-    bool checked_circuit_res = composer.check_circuit();
-    printf("check_circuit result: %d\n", checked_circuit_res);
-
     auto num_gates = composer.get_num_gates();
     return static_cast<uint32_t>(num_gates);
 }


### PR DESCRIPTION
In this PR (https://github.com/noir-lang/aztec_backend/pull/55) we moved to using `get_exact_circuit_size` for calculating the rounded prover circuit size. That means `get_exact_circuit_size` gets called everytime we construct a StandardComposer in the `aztec_backend`. We should remove the print to declutter the output as this was originally put in to test some buggy circuits.