### PR TITLE
fix: Remove proving key buf len estimation

### DIFF
--- a/barretenberg/src/aztec/rollup/proofs/standard_example/standard_example.cpp
+++ b/barretenberg/src/aztec/rollup/proofs/standard_example/standard_example.cpp
@@ -178,20 +178,12 @@ size_t c_init_proving_key(uint8_t const* constraint_system_buf, uint8_t const** 
     auto composer = create_circuit(constraint_system, std::move(crs_factory));
     auto proving_key = composer.compute_proving_key();
 
-    // Computing the size of the serialized key is non trivial. We know it's ~331mb.
-    // Allocate a buffer large enough to hold it, and abort if we overflow.
-    // This is to keep memory usage down.
-    size_t total_buf_len = 350 * 1024 * 1024;
-    auto raw_buf = (uint8_t*)malloc(total_buf_len);
-    auto raw_buf_end = raw_buf;
-    write(raw_buf_end, *proving_key);
+    auto buffer = to_buffer(*proving_key);
+    auto raw_buf = (uint8_t*)malloc(buffer.size());
+    memcpy(raw_buf, (void*)buffer.data(), buffer.size());
     *pk_buf = raw_buf;
-    auto len = static_cast<uint32_t>(raw_buf_end - raw_buf);
-    if (len > total_buf_len) {
-        info("Buffer overflow serializing proving key.");
-        std::abort();
-    }
-    return len;
+
+    return buffer.size();
 }
 
 size_t c_init_verification_key(void* pippenger, uint8_t const* g2x, uint8_t const* pk_buf, uint8_t const** vk_buf)


### PR DESCRIPTION
In [https://github.com/AztecProtocol/barretenberg/blob/f2fdebe037d4d2d90761f98e28b4b0d[…]3/cpp/src/aztec/join_split_example/proofs/join_split/c_bind.cpp](https://github.com/AztecProtocol/barretenberg/blob/f2fdebe037d4d2d90761f98e28b4b0d3af9a0f63/cpp/src/aztec/join_split_example/proofs/join_split/c_bind.cpp#L48) we estimate the size of the proving key before writing it to a buffer (as per the comments it is difficult to compute the size of the serialized key, and there was a desire to keep memory usage down).  This is fine for individual circuits, however, when trying to generalize the circuits for Noir this will lead to a max proving key size. It looks like keeping this write strategy will require constructing some sort of method for estimating the proving key size if I don't want to allocate a massive buffer each time.

This PR switches to using the same write strategy for proving keys that is used for verification keys ([https://github.com/AztecProtocol/barretenberg/blob/f2fdebe037d4d2d90761f98e28b4b0d[…]3/cpp/src/aztec/join_split_example/proofs/join_split/c_bind.cpp](https://github.com/AztecProtocol/barretenberg/blob/f2fdebe037d4d2d90761f98e28b4b0d3af9a0f63/cpp/src/aztec/join_split_example/proofs/join_split/c_bind.cpp#L80)). Using this same write strategy with proving keys looks to be working for my tests. I successfully proved and verified circuits locally using varying examples of small to large circuits. This seems like the best strategy at the moment especially if the current comments in bb mention that estimating the proving key is nontrivial.