### PR TITLE
draft: Use upstream bb and nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 dest
 .cache
+
+result

--- a/barretenberg_wrapper/Cargo.lock
+++ b/barretenberg_wrapper/Cargo.lock
@@ -3,32 +3,6 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "autocfg"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
 name = "barretenberg_wrapper"
 version = "0.1.0"
 dependencies = [
@@ -40,15 +14,13 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.60.1"
+version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
+checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
 dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "clap",
- "env_logger",
  "lazy_static",
  "lazycell",
  "log",
@@ -58,6 +30,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
+ "syn",
  "which",
 ]
 
@@ -100,30 +73,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "3.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b71c3ce99b7611011217b366d923f1d0a7e07a92bb2dbf1e84508c673ca3bd"
-dependencies = [
- "atty",
- "bitflags",
- "clap_lex",
- "indexmap",
- "strsim",
- "termcolor",
- "textwrap",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
-
-[[package]]
 name = "cmake"
 version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,60 +88,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
-name = "env_logger"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
-name = "indexmap"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
-dependencies = [
- "autocfg",
- "hashbrown",
-]
 
 [[package]]
 name = "lazy_static"
@@ -269,12 +174,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
 
 [[package]]
-name = "os_str_bytes"
-version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
-
-[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,9 +181,9 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -304,8 +203,6 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
- "aho-corasick",
- "memchr",
  "regex-syntax",
 ]
 
@@ -328,25 +225,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
-name = "strsim"
-version = "0.10.0"
+name = "syn"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "termcolor"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "winapi-util",
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "unicode-ident"
@@ -380,15 +267,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/barretenberg_wrapper/Cargo.lock
+++ b/barretenberg_wrapper/Cargo.lock
@@ -7,9 +7,8 @@ name = "barretenberg_wrapper"
 version = "0.1.0"
 dependencies = [
  "bindgen",
- "cmake",
  "hex",
- "num_cpus",
+ "pkg-config",
 ]
 
 [[package]]
@@ -41,12 +40,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "cc"
-version = "1.0.72"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
-
-[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -70,15 +63,6 @@ dependencies = [
  "glob",
  "libc",
  "libloading",
-]
-
-[[package]]
-name = "cmake"
-version = "0.1.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ad8cef104ac57b68b89df3208164d228503abbdce70f6880ffa3d970e7443a"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -159,15 +143,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee7e88156f3f9e19bdd598f8d6c9db7bf4078f99f8381f43a55b09648d1a6e3"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,6 +153,12 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "proc-macro2"

--- a/barretenberg_wrapper/Cargo.lock
+++ b/barretenberg_wrapper/Cargo.lock
@@ -56,9 +56,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clang-sys"
-version = "1.3.3"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a050e2153c5be08febd6734e29298e844fdb0fa21aeddd63b4eb7baa106c69b"
+checksum = "77ed9a53e5d4d9c573ae844bfac6872b159cb1d1585a83b29e7a64b7eef7332a"
 dependencies = [
  "glob",
  "libc",

--- a/barretenberg_wrapper/Cargo.toml
+++ b/barretenberg_wrapper/Cargo.toml
@@ -10,5 +10,5 @@ hex = "0.4.2"
 
 [build-dependencies]
 cmake = "0.1.48"
-bindgen = "0.60.1"
+bindgen = "0.64.0"
 num_cpus = "0.2"

--- a/barretenberg_wrapper/Cargo.toml
+++ b/barretenberg_wrapper/Cargo.toml
@@ -9,6 +9,5 @@ edition = "2018"
 hex = "0.4.2"
 
 [build-dependencies]
-cmake = "0.1.48"
 bindgen = "0.64.0"
-num_cpus = "0.2"
+pkg-config = "0.3"

--- a/barretenberg_wrapper/build.rs
+++ b/barretenberg_wrapper/build.rs
@@ -1,44 +1,11 @@
 use std::{env, path::PathBuf};
+
 // These are the operating systems that are supported
 pub enum OS {
     Linux,
     Apple,
 }
-// These are the supported architectures
-pub enum Arch {
-    X86_64,
-    Arm,
-}
-// These constants correspond to the filenames in cmake/toolchains
-//
-// There are currently no toolchain for windows, please use WSL
-const INTEL_APPLE: &str = "x86_64-apple-clang";
-const INTEL_LINUX: &str = "x86_64-linux-clang";
-const ARM_APPLE: &str = "arm-apple-clang";
-const ARM_LINUX: &str = "aarch64-linux-clang";
 
-fn select_toolchain() -> &'static str {
-    let arch = select_arch();
-    let os = select_os();
-    match (os, arch) {
-        (OS::Linux, Arch::X86_64) => INTEL_LINUX,
-        (OS::Linux, Arch::Arm) => ARM_LINUX,
-        (OS::Apple, Arch::X86_64) => INTEL_APPLE,
-        (OS::Apple, Arch::Arm) => ARM_APPLE,
-    }
-}
-fn select_arch() -> Arch {
-    let arch = std::env::consts::ARCH;
-    match arch {
-        "arm" => Arch::Arm,
-        "aarch64" => Arch::Arm,
-        "x86_64" => Arch::X86_64,
-        _ => {
-            // For other arches, we default to x86_64
-            Arch::X86_64
-        }
-    }
-}
 fn select_os() -> OS {
     let os = std::env::consts::OS;
     match os {
@@ -58,207 +25,51 @@ fn select_cpp_stdlib() -> &'static str {
         OS::Apple => "c++",
     }
 }
-fn set_brew_env_var(toolchain: &'static str) {
-    // The cmake file for macos uses an environment variable
-    // to figure out where to find certain programs installed via brew
-    if toolchain == INTEL_APPLE || toolchain == ARM_APPLE {
-        env::set_var("BREW_PREFIX", find_brew_prefix());
-    }
-}
 
 fn main() {
-    // Builds the project in ../barretenberg into dst
-    println!("cargo:rerun-if-changed=../barretenberg");
-
-    // Select toolchain
-    let toolchain = select_toolchain();
-
-    // Set brew environment variable if needed
-    // TODO: We could check move this to a bash script along with
-    // TODO: checks that check that all the necessary dependencies are
-    // TODO installed via llvm
-    set_brew_env_var(toolchain);
-
-    let dst = cmake::Config::new("../barretenberg")
-        .very_verbose(true)
-        .cxxflag("-fPIC")
-        .cxxflag("-fPIE")
-        .env("NUM_JOBS", num_cpus::get().to_string())
-        .define("TOOLCHAIN", toolchain)
-        .define("TESTING", "OFF")
-        .define("DISABLE_ASM", "ON")
-        .define("DISABLE_ADX", "ON")
-        .always_configure(false)
-        .build();
-
     // Manually link all of the libraries
 
     // Link C++ std lib
     println!("cargo:rustc-link-lib={}", select_cpp_stdlib());
-    // Link lib OpenMP
-    link_lib_omp(toolchain);
-
-    // println!(
-    //     "cargo:rustc-link-search={}/build/src/aztec/bb",
-    //     dst.display()
-    // );
-    // println!("cargo:rustc-link-lib=static=bb");
-
-    println!(
-        "cargo:rustc-link-search={}/build/src/aztec/crypto/blake2s",
-        dst.display()
-    );
-    println!("cargo:rustc-link-lib=static=crypto_blake2s");
-
-    println!(
-        "cargo:rustc-link-search={}/build/src/aztec/env",
-        dst.display()
-    );
-    println!("cargo:rustc-link-lib=static=env");
-
-    println!(
-        "cargo:rustc-link-search={}/build/src/aztec/crypto/pedersen",
-        dst.display()
-    );
-    println!("cargo:rustc-link-lib=static=crypto_pedersen");
-    println!(
-        "cargo:rustc-link-search={}/build/src/aztec/ecc",
-        dst.display()
-    );
-    println!("cargo:rustc-link-lib=static=ecc");
-    println!(
-        "cargo:rustc-link-search={}/build/src/aztec/crypto/keccak",
-        dst.display()
-    );
-    println!("cargo:rustc-link-lib=static=crypto_keccak");
-
-    println!(
-        "cargo:rustc-link-search={}/build/src/aztec/crypto/schnorr",
-        dst.display()
-    );
-    println!("cargo:rustc-link-lib=static=crypto_schnorr");
-
-    println!(
-        "cargo:rustc-link-search={}/build/src/aztec/dsl",
-        dst.display()
-    );
-    println!("cargo:rustc-link-lib=static=dsl");
-
-    println!(
-        "cargo:rustc-link-search={}/build/src/aztec/plonk/",
-        dst.display()
-    );
-    println!("cargo:rustc-link-lib=static=plonk");
-    println!(
-        "cargo:rustc-link-search={}/build/src/aztec/polynomials/",
-        dst.display()
-    );
-    println!("cargo:rustc-link-lib=static=polynomials");
-    println!(
-        "cargo:rustc-link-search={}/build/src/aztec/srs/",
-        dst.display()
-    );
-    println!("cargo:rustc-link-lib=static=srs");
-    println!(
-        "cargo:rustc-link-search={}/build/src/aztec/numeric/",
-        dst.display()
-    );
-    println!("cargo:rustc-link-lib=static=numeric");
-
-    println!(
-        "cargo:rustc-link-search={}/build/src/aztec/stdlib/primitives",
-        dst.display()
-    );
-    println!(
-        "cargo:rustc-link-search={}/build/src/aztec/stdlib/hash/sha256",
-        dst.display()
-    );
-    println!(
-        "cargo:rustc-link-search={}/build/src/aztec/stdlib/hash/blake2s",
-        dst.display()
-    );
-    println!(
-        "cargo:rustc-link-search={}/build/src/aztec/stdlib/encryption/schnorr",
-        dst.display()
-    );
-    println!(
-        "cargo:rustc-link-search={}/build/src/aztec/stdlib/hash/pedersen",
-        dst.display()
-    );
-
-    println!("cargo:rustc-link-lib=static=stdlib_primitives");
-    println!("cargo:rustc-link-lib=static=stdlib_sha256");
-    println!("cargo:rustc-link-lib=static=stdlib_blake2s");
-    println!("cargo:rustc-link-lib=static=stdlib_schnorr");
-    println!("cargo:rustc-link-lib=static=stdlib_pedersen");
-
-    println!(
-        "cargo:rustc-link-search={}/build/src/aztec/rollup/proofs/standard_example",
-        dst.display()
-    );
-    println!("cargo:rustc-link-lib=static=rollup_proofs_standard_example");
+    println!("cargo:rustc-link-lib={}", "omp");
+    // NEEDED FOR NON NIX BUILDS
+    // println!("cargo:rustc-link-search=/usr/local/lib");
+    // println!("cargo:rustc-link-search=/Users/phated/brew/opt/llvm/lib");
 
     // Generate bindings from a header file and place them in a bindings.rs file
     let bindings = bindgen::Builder::default()
         // Clang args so that we can use relative include paths
-        .clang_args(&["-I../barretenberg/src/aztec", "-I../..", "-I../", "-xc++"])
-        .header("../barretenberg/src/aztec/bb/bb.hpp")
+        .clang_args(&["-std=c++20", "-xc++"])
+        .header_contents(
+            "wrapper.h",
+            r#"
+            #include <aztec/dsl/turbo_proofs/c_bind.hpp>
+            #include <aztec/crypto/blake2s/c_bind.hpp>
+            #include <aztec/crypto/pedersen/c_bind.hpp>
+            #include <aztec/crypto/schnorr/c_bind.hpp>
+            #include <aztec/ecc/curves/bn254/scalar_multiplication/c_bind.hpp>
+            "#,
+        )
+        .allowlist_function("blake2s_to_field")
+        .allowlist_function("turbo_get_exact_circuit_size")
+        .allowlist_function("turbo_init_proving_key")
+        .allowlist_function("turbo_init_verification_key")
+        .allowlist_function("turbo_new_proof")
+        .allowlist_function("turbo_verify_proof")
+        .allowlist_function("pedersen__compress_fields")
+        .allowlist_function("pedersen__compress")
+        .allowlist_function("pedersen__commit")
+        .allowlist_function("new_pippenger")
+        .allowlist_function("compute_public_key")
+        .allowlist_function("construct_signature")
+        .allowlist_function("verify_signature")
         .generate()
         .expect("Unable to generate bindings");
+
+    println!("cargo:rustc-link-lib=static=barretenberg");
+
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
     bindings
         .write_to_file(out_path.join("bindings.rs"))
         .expect("Couldn't write bindings");
-}
-
-fn link_lib_omp(toolchain: &'static str) {
-    // We are using clang, so we need to tell the linker where to search for lomp
-    match toolchain {
-        INTEL_LINUX | ARM_LINUX => {
-            let llvm_dir = find_llvm_linux_path();
-            println!("cargo:rustc-link-search={llvm_dir}/lib")
-        }
-        INTEL_APPLE => {
-            let brew_prefix = find_brew_prefix();
-            println!("cargo:rustc-link-search={brew_prefix}/opt/libomp/lib")
-        }
-        ARM_APPLE => {
-            let brew_prefix = find_brew_prefix();
-            println!("cargo:rustc-link-search={brew_prefix}/opt/libomp/lib")
-        }
-        &_ => unimplemented!("lomp linking of {toolchain} is not supported"),
-    }
-    match toolchain {
-        ARM_LINUX | INTEL_APPLE | ARM_APPLE => {
-            println!("cargo:rustc-link-lib=omp")
-        }
-        &_ => println!("cargo:rustc-link-lib=omp5"),
-    }
-}
-
-fn find_llvm_linux_path() -> String {
-    // Most linux systems will have the `find` application
-    //
-    // This assumes that there is a single llvm-X folder in /usr/lib
-    let output = std::process::Command::new("sh")
-        .arg("-c")
-        .arg("find /usr/lib -type d -name \"*llvm-*\" -print -quit")
-        .stdout(std::process::Stdio::piped())
-        .output()
-        .expect("Failed to execute command to run `find`");
-    // This should be the path to llvm
-    let path_to_llvm = String::from_utf8(output.stdout).unwrap();
-    path_to_llvm.trim().to_owned()
-}
-
-fn find_brew_prefix() -> String {
-    let output = std::process::Command::new("brew")
-        .arg("--prefix")
-        .stdout(std::process::Stdio::piped())
-        .output()
-        .expect("Failed to execute command to run `brew --prefix` is brew installed?");
-
-    let stdout = String::from_utf8(output.stdout).unwrap();
-
-    stdout.trim().to_string()
 }

--- a/barretenberg_wrapper/build.rs
+++ b/barretenberg_wrapper/build.rs
@@ -7,8 +7,7 @@ pub enum OS {
 }
 
 fn select_os() -> OS {
-    let os = std::env::consts::OS;
-    match os {
+    match env::consts::OS {
         "linux" => OS::Linux,
         "macos" => OS::Apple,
         "windows" => unimplemented!("windows is not supported"),

--- a/barretenberg_wrapper/build.rs
+++ b/barretenberg_wrapper/build.rs
@@ -39,9 +39,9 @@ fn main() {
     // Generate bindings from a header file and place them in a bindings.rs file
     let bindings = bindgen::Builder::default()
         // Clang args so that we can use relative include paths
-        .clang_args(&["-std=c++20", "-xc++"])
+        .clang_args(&["-std=gnu++20", "-xc++"])
         .header_contents(
-            "wrapper.h",
+            "wrapper.hpp",
             r#"
             #include <barretenberg/dsl/turbo_proofs/c_bind.hpp>
             #include <barretenberg/crypto/blake2s/c_bind.hpp>

--- a/barretenberg_wrapper/flake.lock
+++ b/barretenberg_wrapper/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1677880741,
-        "narHash": "sha256-fer3cp37mR+CI7Y5Dq0efG+9FkmW9dIoO6/7XMQSKCs=",
+        "lastModified": 1678141351,
+        "narHash": "sha256-Tu3XbJKPieCT6mCCqlP5o/EQsOI7lyANF2DXJ1R1Pco=",
         "owner": "AztecProtocol",
         "repo": "barretenberg",
-        "rev": "3330d602b3a743f99e3756c82f859831c79e3410",
+        "rev": "4dcce47887a1eead5a2627a898e994709e7a43ca",
         "type": "github"
       },
       "original": {
@@ -34,11 +34,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1677642623,
-        "narHash": "sha256-GlRa6/HWg8mIxPM29ZuTP2dP8y9sQ6BdbrjzCO8JgAo=",
+        "lastModified": 1677892403,
+        "narHash": "sha256-/Wi0L1spSWLFj+UQxN3j0mPYMoc7ZoAujpUF/juFVII=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "f3f763e4d9f156ec0c37f39b0f77e2d62213b296",
+        "rev": "105e27adb70a9890986b6d543a67761cbc1964a2",
         "type": "github"
       },
       "original": {
@@ -95,11 +95,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1677852945,
-        "narHash": "sha256-liiVJjkBTuBTAkRW3hrI8MbPD2ImYzwUpa7kvteiKhM=",
+        "lastModified": 1678086707,
+        "narHash": "sha256-y1uXdxzinIne4FW3TF7DCtxEB9gAbQ4qnbpYzhvkFm8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f5ffd5787786dde3a8bf648c7a1b5f78c4e01abb",
+        "rev": "21eda9bc80bef824a037582b1e5a43ba74e92daa",
         "type": "github"
       },
       "original": {
@@ -130,11 +130,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1676437770,
-        "narHash": "sha256-mhJye91Bn0jJIE7NnEywGty/U5qdELfsT8S+FBjTdG4=",
+        "lastModified": 1677812689,
+        "narHash": "sha256-EakqhgRnjVeYJv5+BJx/NZ7/eFTMBxc4AhICUNquhUg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "a619538647bd03e3ee1d7b947f7c11ff289b376e",
+        "rev": "e53e8853aa7b0688bc270e9e6a681d22e01cf299",
         "type": "github"
       },
       "original": {
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1677812689,
-        "narHash": "sha256-EakqhgRnjVeYJv5+BJx/NZ7/eFTMBxc4AhICUNquhUg=",
+        "lastModified": 1678069954,
+        "narHash": "sha256-52oErh9xblq9hS3eQurgKLVT8W85TpcMB7mIJCaGuIk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "e53e8853aa7b0688bc270e9e6a681d22e01cf299",
+        "rev": "695b8bb0af23d4ad3826fe7a372a5d677ad5c2bd",
         "type": "github"
       },
       "original": {

--- a/barretenberg_wrapper/flake.lock
+++ b/barretenberg_wrapper/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678313828,
-        "narHash": "sha256-7NxyGEeYtZ7uKbTwAuls/o9Mpk+XjYOEy7nkDdCDnkY=",
+        "lastModified": 1678389960,
+        "narHash": "sha256-DTHzcAsUuG72zsSkRqqiNyHt4wyCEazEA6WeEJBKkII=",
         "owner": "AztecProtocol",
         "repo": "barretenberg",
-        "rev": "8ac2d72e942fd5e0f95ca876fef6c4a80a55ad0e",
+        "rev": "92fbb15df66e286b5c69bd7bbf4f7bfabef35c16",
         "type": "github"
       },
       "original": {
@@ -95,11 +95,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1678268259,
-        "narHash": "sha256-q+ZWNJfXKgIKwsZBir0yXrmIV/4tOv5BflxDAfGISps=",
+        "lastModified": 1678298120,
+        "narHash": "sha256-iaV5xqgn29xy765Js3EoZePQyZIlLZA3pTYtTnKkejg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "90ef5c3c337d8d9f0c97e7641ece70a41f6c16a2",
+        "rev": "1e383aada51b416c6c27d4884d2e258df201bc11",
         "type": "github"
       },
       "original": {
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678242776,
-        "narHash": "sha256-36K1Rg2vM+NLqORSBL4e3aZHmgkb6aS9upHsuG4Akns=",
+        "lastModified": 1678329167,
+        "narHash": "sha256-0mOD5FOq8ZX0wieZxZOp7ORszsiVyF3U2UQ2/RXXqqQ=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "ea311f10a5d51e7588799281bab0556b4e978d00",
+        "rev": "cb22476a4d0e0b8b21900d220c2b1cf830821f9d",
         "type": "github"
       },
       "original": {

--- a/barretenberg_wrapper/flake.lock
+++ b/barretenberg_wrapper/flake.lock
@@ -10,16 +10,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1678389960,
-        "narHash": "sha256-DTHzcAsUuG72zsSkRqqiNyHt4wyCEazEA6WeEJBKkII=",
+        "lastModified": 1678403292,
+        "narHash": "sha256-BIZ0aM0WF6pzYMOfiEdEKv+J0jEx6wbwkM5DsX1xMs0=",
         "owner": "AztecProtocol",
         "repo": "barretenberg",
-        "rev": "92fbb15df66e286b5c69bd7bbf4f7bfabef35c16",
+        "rev": "31315345b507dd67540e16b43627cf0c2c0dabd1",
         "type": "github"
       },
       "original": {
         "owner": "AztecProtocol",
-        "ref": "phated/nix-acir-format",
+        "ref": "phated/nix",
         "repo": "barretenberg",
         "type": "github"
       }
@@ -95,16 +95,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1678298120,
-        "narHash": "sha256-iaV5xqgn29xy765Js3EoZePQyZIlLZA3pTYtTnKkejg=",
+        "lastModified": 1678230755,
+        "narHash": "sha256-SFAXgNjNTXzcAideXcP0takfUGVft/VR5CACmYHg+Fc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1e383aada51b416c6c27d4884d2e258df201bc11",
+        "rev": "a7cc81913bb3cd1ef05ed0ece048b773e1839e51",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-22.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678329167,
-        "narHash": "sha256-0mOD5FOq8ZX0wieZxZOp7ORszsiVyF3U2UQ2/RXXqqQ=",
+        "lastModified": 1678397831,
+        "narHash": "sha256-7xbxSoiht8G+Zgz55R0ILPsTdbnksILCDMIxeg8Buns=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "cb22476a4d0e0b8b21900d220c2b1cf830821f9d",
+        "rev": "bdf08e2f43488283eeb25b4a7e7ecba9147a955c",
         "type": "github"
       },
       "original": {

--- a/barretenberg_wrapper/flake.lock
+++ b/barretenberg_wrapper/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678312996,
-        "narHash": "sha256-6Vq/p7mJ078e3gCXm/ggL4cT+HhqcK2mWXv7oeLbFZw=",
+        "lastModified": 1678313828,
+        "narHash": "sha256-7NxyGEeYtZ7uKbTwAuls/o9Mpk+XjYOEy7nkDdCDnkY=",
         "owner": "AztecProtocol",
         "repo": "barretenberg",
-        "rev": "95f9d0a061fd35482a2751aebb6940d5fb2b2ad4",
+        "rev": "8ac2d72e942fd5e0f95ca876fef6c4a80a55ad0e",
         "type": "github"
       },
       "original": {

--- a/barretenberg_wrapper/flake.lock
+++ b/barretenberg_wrapper/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678141351,
-        "narHash": "sha256-Tu3XbJKPieCT6mCCqlP5o/EQsOI7lyANF2DXJ1R1Pco=",
+        "lastModified": 1678312996,
+        "narHash": "sha256-6Vq/p7mJ078e3gCXm/ggL4cT+HhqcK2mWXv7oeLbFZw=",
         "owner": "AztecProtocol",
         "repo": "barretenberg",
-        "rev": "4dcce47887a1eead5a2627a898e994709e7a43ca",
+        "rev": "95f9d0a061fd35482a2751aebb6940d5fb2b2ad4",
         "type": "github"
       },
       "original": {
@@ -34,11 +34,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1677892403,
-        "narHash": "sha256-/Wi0L1spSWLFj+UQxN3j0mPYMoc7ZoAujpUF/juFVII=",
+        "lastModified": 1678152261,
+        "narHash": "sha256-cPRDxwygVMleiSEGELrvAiq9vYAN4c3KK/K4UEO13vU=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "105e27adb70a9890986b6d543a67761cbc1964a2",
+        "rev": "5291dd0aa7a52d607fc952763ef60714e4c881d4",
         "type": "github"
       },
       "original": {
@@ -95,11 +95,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1678086707,
-        "narHash": "sha256-y1uXdxzinIne4FW3TF7DCtxEB9gAbQ4qnbpYzhvkFm8=",
+        "lastModified": 1678268259,
+        "narHash": "sha256-q+ZWNJfXKgIKwsZBir0yXrmIV/4tOv5BflxDAfGISps=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "21eda9bc80bef824a037582b1e5a43ba74e92daa",
+        "rev": "90ef5c3c337d8d9f0c97e7641ece70a41f6c16a2",
         "type": "github"
       },
       "original": {
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678069954,
-        "narHash": "sha256-52oErh9xblq9hS3eQurgKLVT8W85TpcMB7mIJCaGuIk=",
+        "lastModified": 1678242776,
+        "narHash": "sha256-36K1Rg2vM+NLqORSBL4e3aZHmgkb6aS9upHsuG4Akns=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "695b8bb0af23d4ad3826fe7a372a5d677ad5c2bd",
+        "rev": "ea311f10a5d51e7588799281bab0556b4e978d00",
         "type": "github"
       },
       "original": {

--- a/barretenberg_wrapper/flake.lock
+++ b/barretenberg_wrapper/flake.lock
@@ -1,0 +1,172 @@
+{
+  "nodes": {
+    "barretenberg": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1677880741,
+        "narHash": "sha256-fer3cp37mR+CI7Y5Dq0efG+9FkmW9dIoO6/7XMQSKCs=",
+        "owner": "AztecProtocol",
+        "repo": "barretenberg",
+        "rev": "3330d602b3a743f99e3756c82f859831c79e3410",
+        "type": "github"
+      },
+      "original": {
+        "owner": "AztecProtocol",
+        "ref": "phated/nix-acir-format",
+        "repo": "barretenberg",
+        "type": "github"
+      }
+    },
+    "crane": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1677642623,
+        "narHash": "sha256-GlRa6/HWg8mIxPM29ZuTP2dP8y9sQ6BdbrjzCO8JgAo=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "f3f763e4d9f156ec0c37f39b0f77e2d62213b296",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1677852945,
+        "narHash": "sha256-liiVJjkBTuBTAkRW3hrI8MbPD2ImYzwUpa7kvteiKhM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f5ffd5787786dde3a8bf648c7a1b5f78c4e01abb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "barretenberg": "barretenberg",
+        "crane": "crane",
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay_2"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "crane",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "crane",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1676437770,
+        "narHash": "sha256-mhJye91Bn0jJIE7NnEywGty/U5qdELfsT8S+FBjTdG4=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "a619538647bd03e3ee1d7b947f7c11ff289b376e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_2": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1677812689,
+        "narHash": "sha256-EakqhgRnjVeYJv5+BJx/NZ7/eFTMBxc4AhICUNquhUg=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "e53e8853aa7b0688bc270e9e6a681d22e01cf299",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/barretenberg_wrapper/flake.nix
+++ b/barretenberg_wrapper/flake.nix
@@ -41,6 +41,7 @@
         };
 
         craneLib = (crane.mkLib pkgs).overrideScope' (final: prev: {
+          # As per https://discourse.nixos.org/t/gcc11stdenv-and-clang/17734/7
           stdenv = with pkgs; overrideCC llvmPackages.stdenv (llvmPackages.clang.override { gccForLibs = gcc11.cc; });
         });
 

--- a/barretenberg_wrapper/flake.nix
+++ b/barretenberg_wrapper/flake.nix
@@ -41,7 +41,7 @@
         };
 
         craneLib = (crane.mkLib pkgs).overrideScope' (final: prev: {
-          stdenv = pkgs.llvmPackages.stdenv;
+          stdenv = with pkgs; overrideCC llvmPackages.stdenv (llvmPackages.clang.override { gccForLibs = gcc11.cc; });
         });
 
         barretenberg-rs = craneLib.buildPackage {
@@ -51,6 +51,7 @@
 
           nativeBuildInputs = [
             pkgs.pkg-config
+            pkgs.llvmPackages.bintools
           ];
 
           buildInputs = [

--- a/barretenberg_wrapper/flake.nix
+++ b/barretenberg_wrapper/flake.nix
@@ -1,0 +1,81 @@
+{
+  description = "Build Barretenberg wrapper";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+    crane = {
+      url = "github:ipetkov/crane";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    flake-utils.url = "github:numtide/flake-utils";
+
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        flake-utils.follows = "flake-utils";
+      };
+    };
+
+    barretenberg = {
+      url = "github:AztecProtocol/barretenberg/phated/nix-acir-format";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        flake-utils.follows = "flake-utils";
+      };
+    };
+  };
+
+  outputs =
+    { self, nixpkgs, crane, flake-utils, rust-overlay, barretenberg, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            rust-overlay.overlays.default
+            barretenberg.overlays.default
+          ];
+        };
+
+        craneLib = (crane.mkLib pkgs).overrideScope' (final: prev: {
+          stdenv = pkgs.llvmPackages.stdenv;
+        });
+
+        barretenberg-rs = craneLib.buildPackage {
+          src = craneLib.cleanCargoSource ./.;
+
+          doCheck = false;
+
+          # Bindgen needs these
+          # BINDGEN_EXTRA_CLANG_ARGS = "-L${pkgs.barretenberg}";
+          RUSTFLAGS = "-L${pkgs.barretenberg}/lib -lomp";
+
+          buildInputs = [
+            pkgs.llvmPackages.openmp
+            pkgs.barretenberg
+          ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+            pkgs.libiconv
+          ];
+        };
+      in rec {
+        checks = { inherit barretenberg-rs; };
+
+        packages.default = barretenberg-rs;
+
+        devShells.default = pkgs.mkShell {
+          inputsFrom = builtins.attrValues self.checks;
+
+          buildInputs = packages.default.buildInputs ;
+
+          # BINDGEN_EXTRA_CLANG_ARGS = "-I${pkgs.barretenberg}/include/aztec -L${pkgs.barretenberg}";
+          RUSTFLAGS = "-L${pkgs.barretenberg}/lib -lomp";
+
+          nativeBuildInputs = with pkgs; [
+            cargo
+            rustc ];
+        };
+      });
+}

--- a/barretenberg_wrapper/flake.nix
+++ b/barretenberg_wrapper/flake.nix
@@ -55,6 +55,9 @@
             pkgs.llvmPackages.bintools
           ];
 
+          # rust-bindgen needs to know the location of libclang
+          LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+
           buildInputs = [
             pkgs.llvmPackages.openmp
             pkgs.barretenberg

--- a/barretenberg_wrapper/flake.nix
+++ b/barretenberg_wrapper/flake.nix
@@ -2,7 +2,7 @@
   description = "Build Barretenberg wrapper";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
 
     crane = {
       url = "github:ipetkov/crane";
@@ -20,7 +20,7 @@
     };
 
     barretenberg = {
-      url = "github:AztecProtocol/barretenberg/phated/nix-acir-format";
+      url = "github:AztecProtocol/barretenberg/phated/nix";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-utils.follows = "flake-utils";

--- a/barretenberg_wrapper/flake.nix
+++ b/barretenberg_wrapper/flake.nix
@@ -49,9 +49,9 @@
 
           doCheck = false;
 
-          # Bindgen needs these
-          # BINDGEN_EXTRA_CLANG_ARGS = "-L${pkgs.barretenberg}";
-          RUSTFLAGS = "-L${pkgs.barretenberg}/lib -lomp";
+          nativeBuildInputs = [
+            pkgs.pkg-config
+          ];
 
           buildInputs = [
             pkgs.llvmPackages.openmp
@@ -68,14 +68,8 @@
         devShells.default = pkgs.mkShell {
           inputsFrom = builtins.attrValues self.checks;
 
-          buildInputs = packages.default.buildInputs ;
-
-          # BINDGEN_EXTRA_CLANG_ARGS = "-I${pkgs.barretenberg}/include/aztec -L${pkgs.barretenberg}";
-          RUSTFLAGS = "-L${pkgs.barretenberg}/lib -lomp";
-
-          nativeBuildInputs = with pkgs; [
-            cargo
-            rustc ];
+          buildInputs = packages.default.buildInputs;
+          nativeBuildInputs = packages.default.nativeBuildInputs;
         };
       });
 }

--- a/barretenberg_wrapper/src/blake2s.rs
+++ b/barretenberg_wrapper/src/blake2s.rs
@@ -4,7 +4,7 @@ pub fn hash_to_field(input: &[u8]) -> [u8; 32] {
     let mut r = [0_u8; 32];
     let data = input.as_ptr() as *const u8;
     unsafe {
-        blake2s_to_field(data, input.len() as u64, r.as_mut_ptr());
+        blake2s_to_field(data, input.len(), r.as_mut_ptr());
     }
     r
 }

--- a/barretenberg_wrapper/src/composer.rs
+++ b/barretenberg_wrapper/src/composer.rs
@@ -3,75 +3,25 @@ use crate::*;
 /// # Safety
 /// pippenger must point to a valid Pippenger object
 pub unsafe fn smart_contract(
-    pippenger: *mut ::std::os::raw::c_void,
-    g2_ptr: &[u8],
-    cs_ptr: &[u8],
-    output_buf: *mut *mut u8,
+    _pippenger: *mut ::std::os::raw::c_void,
+    _g2_ptr: &[u8],
+    _cs_ptr: &[u8],
+    _output_buf: *mut *mut u8,
 ) -> u32 {
-    composer__smart_contract(
-        pippenger,
-        g2_ptr.as_ptr() as *const u8,
-        cs_ptr.as_ptr() as *const u8,
-        output_buf,
-    )
-}
-
-/// # Safety
-/// cs_prt must point to a valid constraints system structure of type standard_format
-pub unsafe fn get_circuit_size(cs_prt: *const u8) -> u32 {
-    composer__get_circuit_size(cs_prt)
-    // TODO test with a circuit of size 2^19 cf: https://github.com/noir-lang/noir/issues/12
+    unimplemented!()
 }
 
 /// # Safety
 /// cs_prt must point to a valid constraints system structure of type standard_format
 pub unsafe fn get_exact_circuit_size(cs_prt: *const u8) -> u32 {
-    standard_example__get_exact_circuit_size(cs_prt)
-}
-
-/// # Safety
-/// pippenger must point to a valid Pippenger object
-pub unsafe fn create_proof(
-    pippenger: *mut ::std::os::raw::c_void,
-    cs_ptr: &[u8],
-    g2_ptr: &[u8],
-    witness_ptr: &[u8],
-    proof_data_ptr: *mut *mut u8,
-) -> u64 {
-    composer__new_proof(
-        pippenger,
-        g2_ptr.as_ptr() as *const u8,
-        cs_ptr.as_ptr() as *const u8,
-        witness_ptr.as_ptr() as *const u8,
-        proof_data_ptr as *const *mut u8 as *mut *mut u8,
-    )
-}
-/// # Safety
-/// pippenger must point to a valid Pippenger object
-pub unsafe fn verify(
-    // XXX: Important: This assumes that the proof does not have the public inputs pre-pended to it
-    // This is not the case, if you take the proof directly from Barretenberg
-    pippenger: *mut ::std::os::raw::c_void,
-    proof: &[u8],
-    cs_ptr: &[u8],
-    g2_ptr: &[u8],
-) -> bool {
-    let proof_ptr = proof.as_ptr() as *const u8;
-
-    composer__verify_proof(
-        pippenger,
-        g2_ptr.as_ptr() as *const u8,
-        cs_ptr.as_ptr() as *const u8,
-        proof_ptr as *mut u8,
-        proof.len() as u32,
-    )
+    turbo_get_exact_circuit_size(cs_prt)
 }
 
 /// # Safety
 /// cs_prt must point to a valid constraints system structure of type standard_format
-pub unsafe fn init_proving_key(cs_ptr: &[u8], pk_data_ptr: *mut *mut u8) -> u64 {
-    let cs_ptr = cs_ptr.as_ptr() as *const u8;
-    c_init_proving_key(cs_ptr, pk_data_ptr as *const *mut u8 as *mut *const u8)
+pub unsafe fn init_proving_key(cs_ptr: &[u8], pk_data_ptr: *mut *mut u8) -> usize {
+    let cs_ptr = cs_ptr.as_ptr();
+    turbo_init_proving_key(cs_ptr, pk_data_ptr as *const *mut u8 as *mut *const u8)
 }
 
 /// # Safety
@@ -81,8 +31,8 @@ pub unsafe fn init_verification_key(
     g2_ptr: &[u8],
     pk_ptr: &[u8],
     vk_data_ptr: *mut *mut u8,
-) -> u64 {
-    c_init_verification_key(
+) -> usize {
+    turbo_init_verification_key(
         pippenger,
         g2_ptr.as_ptr() as *const u8,
         pk_ptr.as_ptr() as *const u8,
@@ -99,15 +49,15 @@ pub unsafe fn create_proof_with_pk(
     cs_ptr: &[u8],
     witness_ptr: &[u8],
     proof_data_ptr: *mut *mut u8,
-) -> u64 {
+) -> usize {
     let cs_ptr = cs_ptr.as_ptr() as *const u8;
     let pk_ptr = pk_ptr.as_ptr() as *const u8;
-    c_new_proof(
+    turbo_new_proof(
         pippenger,
-        g2_ptr.as_ptr() as *const u8,
+        g2_ptr.as_ptr(),
         pk_ptr,
         cs_ptr,
-        witness_ptr.as_ptr() as *const u8,
+        witness_ptr.as_ptr(),
         proof_data_ptr as *const *mut u8 as *mut *mut u8,
     )
 }
@@ -117,7 +67,7 @@ pub unsafe fn create_proof_with_pk(
 pub unsafe fn verify_with_vk(g2_ptr: &[u8], vk_ptr: &[u8], cs_ptr: &[u8], proof: &[u8]) -> bool {
     let proof_ptr = proof.as_ptr() as *const u8;
 
-    c_verify_proof(
+    turbo_verify_proof(
         g2_ptr.as_ptr() as *const u8,
         vk_ptr.as_ptr() as *const u8,
         cs_ptr.as_ptr() as *const u8,

--- a/barretenberg_wrapper/src/pippenger.rs
+++ b/barretenberg_wrapper/src/pippenger.rs
@@ -1,7 +1,7 @@
 use crate::*;
 
 pub fn new(crs_data: &[u8]) -> *mut std::os::raw::c_void {
-    let num_points = (crs_data.len() / 64) as u64;
+    let num_points = crs_data.len() / 64;
     let result: *mut std::os::raw::c_void;
     // TODO: this is a problem in the C++ code, it should not
     // TODO: need a mutable pointer

--- a/barretenberg_wrapper/src/schnorr.rs
+++ b/barretenberg_wrapper/src/schnorr.rs
@@ -10,7 +10,7 @@ pub fn fixed_base(input: &[u8; 32]) -> ([u8; 32], [u8; 32]) {
 pub fn construct_public_key(private_key: &[u8; 32]) -> [u8; 64] {
     let mut result = [0_u8; 64];
     unsafe {
-        let data = private_key.as_ptr() as *const u8;
+        let data = private_key.as_ptr();
         compute_public_key(data, result.as_mut_ptr());
     }
     result
@@ -21,9 +21,9 @@ pub fn construct_signature(message: &[u8], private_key: [u8; 32]) -> ([u8; 32], 
     let mut e = [0_u8; 32];
     unsafe {
         crate::construct_signature(
-            message.as_ptr() as *const u8,
-            message.len() as u64,
-            private_key.as_ptr() as *const u8,
+            message.as_ptr(),
+            message.len(),
+            private_key.as_ptr(),
             s.as_mut_ptr(),
             e.as_mut_ptr(),
         );
@@ -42,11 +42,11 @@ pub fn verify_signature(
     let r;
     unsafe {
         r = crate::verify_signature(
-            message.as_ptr() as *const u8,
-            message.len() as u64,
-            pub_key.as_ptr() as *const u8,
-            sig_s.as_ptr() as *const u8,
-            sig_e.as_ptr() as *const u8,
+            message.as_ptr(),
+            message.len(),
+            pub_key.as_ptr(),
+            sig_s.as_ptr(),
+            sig_e.as_ptr(),
         );
     }
     r


### PR DESCRIPTION
This is a draft showing how bb_wrapper can be changed to use upstream barretenberg and nix. This will actually need to be moved into a new crate in aztec_backend but it is easiest to draft here.